### PR TITLE
Integrate Orleans silo into Billing solution

### DIFF
--- a/Billing/src/Billing.AppHost/Billing.AppHost.csproj
+++ b/Billing/src/Billing.AppHost/Billing.AppHost.csproj
@@ -16,6 +16,7 @@
     <ItemGroup>
         <ProjectReference Include="..\Billing.Api\Billing.Api.csproj" />
         <ProjectReference Include="..\Billing.BackOffice\Billing.BackOffice.csproj" />
+        <ProjectReference Include="..\Billing.BackOffice.Orleans\Billing.BackOffice.Orleans.csproj" />
     </ItemGroup>
 
 </Project>

--- a/Billing/src/Billing.AppHost/Billing.AppHost.csproj
+++ b/Billing/src/Billing.AppHost/Billing.AppHost.csproj
@@ -11,6 +11,8 @@
         <PackageReference Include="Aspire.Hosting.AppHost" />
         <PackageReference Include="Aspire.Hosting.Kafka" />
         <PackageReference Include="Aspire.Hosting.PostgreSQL" />
+        <PackageReference Include="Aspire.Hosting.Azure.Storage" />
+        <PackageReference Include="Aspire.Hosting.Orleans" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Billing/src/Billing.AppHost/Program.cs
+++ b/Billing/src/Billing.AppHost/Program.cs
@@ -33,4 +33,12 @@ builder
     .WithReference(serviceBusDb)
     .WaitForCompletion(liquibase);
 
+builder
+    .AddProject<Projects.Billing_BackOffice_Orleans>("billing-backoffice-orleans")
+    .WithEnvironment("ServiceBus__ConnectionString", serviceBusDb)
+    .WithEnvironment("ConnectionStrings__OrleansStorage", "UseDevelopmentStorage=true")
+    .WithReference(database)
+    .WithReference(serviceBusDb)
+    .WaitForCompletion(liquibase);
+
 await builder.Build().RunAsync();

--- a/Billing/src/Billing.BackOffice.Orleans/Billing.BackOffice.Orleans.csproj
+++ b/Billing/src/Billing.BackOffice.Orleans/Billing.BackOffice.Orleans.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <UserSecretsId>e7d9a6d4-a679-4fd9-8ef2-9f85cac1c074</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Platform\src\Operations.ServiceDefaults\Operations.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\Billing\Billing.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Orleans.Server" />
+    <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" />
+    <PackageReference Include="Microsoft.Orleans.Persistence.AzureStorage" />
+  </ItemGroup>
+
+</Project>

--- a/Billing/src/Billing.BackOffice.Orleans/Billing.BackOffice.Orleans.csproj
+++ b/Billing/src/Billing.BackOffice.Orleans/Billing.BackOffice.Orleans.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Orleans.Server" />
     <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" />
     <PackageReference Include="Microsoft.Orleans.Persistence.AzureStorage" />
+    <PackageReference Include="Aspire.Azure.Data.Tables" />
   </ItemGroup>
 
 </Project>

--- a/Billing/src/Billing.BackOffice.Orleans/Program.cs
+++ b/Billing/src/Billing.BackOffice.Orleans/Program.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.Hosting;
+using Orleans.Hosting;
+using Operations.ServiceDefaults;
+using Operations.ServiceDefaults.HealthChecks;
+
+var builder = WebApplication.CreateSlimBuilder(args);
+
+builder.AddServiceDefaults();
+
+builder.Host.UseOrleans((ctx, siloBuilder) =>
+{
+    var connectionString = ctx.Configuration.GetConnectionString("OrleansStorage") ?? "UseDevelopmentStorage=true";
+    siloBuilder
+        .UseAzureStorageClustering(options => options.ConfigureTableServiceClient(connectionString))
+        .AddAzureTableGrainStorageAsDefault(options => options.ConfigureTableServiceClient(connectionString));
+});
+
+var app = builder.Build();
+
+app.MapDefaultHealthCheckEndpoints();
+
+await app.RunAsync();

--- a/Billing/src/Billing.BackOffice.Orleans/Program.cs
+++ b/Billing/src/Billing.BackOffice.Orleans/Program.cs
@@ -1,19 +1,13 @@
 using Microsoft.Extensions.Hosting;
-using Orleans.Hosting;
 using Operations.ServiceDefaults;
 using Operations.ServiceDefaults.HealthChecks;
 
 var builder = WebApplication.CreateSlimBuilder(args);
 
 builder.AddServiceDefaults();
-
-builder.Host.UseOrleans((ctx, siloBuilder) =>
-{
-    var connectionString = ctx.Configuration.GetConnectionString("OrleansStorage") ?? "UseDevelopmentStorage=true";
-    siloBuilder
-        .UseAzureStorageClustering(options => options.ConfigureTableServiceClient(connectionString))
-        .AddAzureTableGrainStorageAsDefault(options => options.ConfigureTableServiceClient(connectionString));
-});
+builder.AddKeyedAzureTableClient("clustering");
+builder.AddKeyedAzureTableClient("grain-state");
+builder.UseOrleans();
 
 var app = builder.Build();
 

--- a/Billing/src/Billing.BackOffice.Orleans/Properties/launchSettings.json
+++ b/Billing/src/Billing.BackOffice.Orleans/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5199",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:7240;http://localhost:5199",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/Billing/src/Billing.BackOffice.Orleans/appsettings.Development.json
+++ b/Billing/src/Billing.BackOffice.Orleans/appsettings.Development.json
@@ -1,0 +1,21 @@
+{
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Billing": "Debug",
+        "Microsoft": "Warning",
+        "Microsoft.AspNetCore": "Warning"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Sixteen, Serilog.Sinks.Console",
+          "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} <s:{SourceContext}>{NewLine}{Exception}"
+        }
+      }
+    ]
+  }
+}

--- a/Billing/src/Billing.BackOffice.Orleans/appsettings.json
+++ b/Billing/src/Billing.BackOffice.Orleans/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "ConnectionStrings": {
+    "OrleansStorage": "UseDevelopmentStorage=true"
+  },
+  "ServiceBus": {
+    "ConnectionString": "Host=localhost;Port=5432;Database=service_bus;"
+  }
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -54,6 +54,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
     <PackageVersion Include="xunit.v3" Version="2.0.3" />
+    <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="9.3.0" />
+    <PackageVersion Include="Aspire.Hosting.Orleans" Version="9.3.0" />
+    <PackageVersion Include="Aspire.Azure.Data.Tables" Version="9.3.0" />
     <PackageVersion Include="Microsoft.Orleans.Server" Version="9.1.2" />
     <PackageVersion Include="Microsoft.Orleans.Clustering.AzureStorage" Version="9.1.2" />
     <PackageVersion Include="Microsoft.Orleans.Persistence.AzureStorage" Version="9.1.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -54,5 +54,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
     <PackageVersion Include="xunit.v3" Version="2.0.3" />
+    <PackageVersion Include="Microsoft.Orleans.Server" Version="9.1.2" />
+    <PackageVersion Include="Microsoft.Orleans.Clustering.AzureStorage" Version="9.1.2" />
+    <PackageVersion Include="Microsoft.Orleans.Persistence.AzureStorage" Version="9.1.2" />
   </ItemGroup>
 </Project>

--- a/Operations.slnx
+++ b/Operations.slnx
@@ -12,6 +12,7 @@
     <Project Path="Billing\src\Billing.Api\Billing.Api.csproj" Type="Classic C#" />
     <Project Path="Billing\src\Billing.AppHost\Billing.AppHost.csproj" Type="Classic C#" />
     <Project Path="Billing\src\Billing.BackOffice\Billing.BackOffice.csproj" Type="Classic C#" />
+    <Project Path="Billing\src\Billing.BackOffice.Orleans\Billing.BackOffice.Orleans.csproj" Type="Classic C#" />
     <Project Path="Billing\src\Billing.Contracts\Billing.Contracts.csproj" Type="Classic C#" />
     <Project Path="Billing\src\Billing\Billing.csproj" Type="Classic C#" />
   </Folder>


### PR DESCRIPTION
## Summary
- add Orleans packages to shared package version management
- create `Billing.BackOffice.Orleans` service using Azure Table for clustering and grain storage
- wire up new Orleans service to Aspire app host and include new project reference
- register new Orleans project in solution file

## Testing
- `dotnet build Operations.slnx`

------
https://chatgpt.com/codex/tasks/task_e_6844f5981f70832288091d515ff1067a