### PR TITLE
Add sample Orleans grain with prod settings

### DIFF
--- a/Billing/src/Billing.AppHost/Billing.AppHost.csproj
+++ b/Billing/src/Billing.AppHost/Billing.AppHost.csproj
@@ -11,11 +11,14 @@
         <PackageReference Include="Aspire.Hosting.AppHost" />
         <PackageReference Include="Aspire.Hosting.Kafka" />
         <PackageReference Include="Aspire.Hosting.PostgreSQL" />
+        <PackageReference Include="Aspire.Hosting.Azure.Storage" />
+        <PackageReference Include="Aspire.Hosting.Orleans" />
     </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\Billing.Api\Billing.Api.csproj" />
         <ProjectReference Include="..\Billing.BackOffice\Billing.BackOffice.csproj" />
+        <ProjectReference Include="..\Billing.BackOffice.Orleans\Billing.BackOffice.Orleans.csproj" />
     </ItemGroup>
 
 </Project>

--- a/Billing/src/Billing.AppHost/Program.cs
+++ b/Billing/src/Billing.AppHost/Program.cs
@@ -19,6 +19,14 @@ var database = pgsql.AddDatabase(name: "BillingDb", databaseName: "billing");
 var serviceBusDb = pgsql.AddDatabase(name: "ServiceBusDb", databaseName: "service_bus");
 var liquibase = builder.AddLiquibaseMigrations(pgsql, dbPassword);
 
+var storage = builder.AddAzureStorage("storage").RunAsEmulator();
+var clustering = storage.AddTables("clustering");
+var grainTables = storage.AddTables("grain-state");
+
+var orleans = builder.AddOrleans("default")
+    .WithClustering(clustering)
+    .WithGrainStorage("Default", grainTables);
+
 builder
     .AddProject<Projects.Billing_Api>("billing-api")
     .WithEnvironment("ServiceBus__ConnectionString", serviceBusDb)
@@ -29,6 +37,14 @@ builder
 builder
     .AddProject<Projects.Billing_BackOffice>("billing-backoffice")
     .WithEnvironment("ServiceBus__ConnectionString", serviceBusDb)
+    .WithReference(database)
+    .WithReference(serviceBusDb)
+    .WaitForCompletion(liquibase);
+
+builder
+    .AddProject<Projects.Billing_BackOffice_Orleans>("billing-backoffice-orleans")
+    .WithEnvironment("ServiceBus__ConnectionString", serviceBusDb)
+    .WithReference(orleans)
     .WithReference(database)
     .WithReference(serviceBusDb)
     .WaitForCompletion(liquibase);

--- a/Billing/src/Billing.BackOffice.Orleans/Billing.BackOffice.Orleans.csproj
+++ b/Billing/src/Billing.BackOffice.Orleans/Billing.BackOffice.Orleans.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <UserSecretsId>e7d9a6d4-a679-4fd9-8ef2-9f85cac1c074</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Platform\src\Operations.ServiceDefaults\Operations.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\Billing\Billing.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Orleans.Server" />
+    <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" />
+    <PackageReference Include="Microsoft.Orleans.Persistence.AzureStorage" />
+    <PackageReference Include="Aspire.Azure.Data.Tables" />
+  </ItemGroup>
+
+</Project>

--- a/Billing/src/Billing.BackOffice.Orleans/Grains/IInvoiceGrain.cs
+++ b/Billing/src/Billing.BackOffice.Orleans/Grains/IInvoiceGrain.cs
@@ -1,0 +1,9 @@
+using Orleans;
+
+namespace Billing.BackOffice.Orleans.Grains;
+
+public interface IInvoiceGrain : IGrainWithGuidKey
+{
+    Task<InvoiceState> GetState();
+    Task Pay(decimal amount);
+}

--- a/Billing/src/Billing.BackOffice.Orleans/Grains/InvoiceGrain.cs
+++ b/Billing/src/Billing.BackOffice.Orleans/Grains/InvoiceGrain.cs
@@ -1,0 +1,18 @@
+using Orleans;
+using Orleans.Runtime;
+
+namespace Billing.BackOffice.Orleans.Grains;
+
+public sealed class InvoiceGrain(
+    [PersistentState("invoice", "Default")] IPersistentState<InvoiceState> state)
+    : Grain, IInvoiceGrain
+{
+    public Task<InvoiceState> GetState() => Task.FromResult(state.State);
+
+    public async Task Pay(decimal amount)
+    {
+        state.State.Amount += amount;
+        state.State.Paid = true;
+        await state.WriteStateAsync();
+    }
+}

--- a/Billing/src/Billing.BackOffice.Orleans/Grains/InvoiceState.cs
+++ b/Billing/src/Billing.BackOffice.Orleans/Grains/InvoiceState.cs
@@ -1,0 +1,12 @@
+using Orleans.Serialization;
+
+namespace Billing.BackOffice.Orleans.Grains;
+
+[GenerateSerializer]
+public sealed class InvoiceState
+{
+    [Id(0)]
+    public decimal Amount { get; set; }
+    [Id(1)]
+    public bool Paid { get; set; }
+}

--- a/Billing/src/Billing.BackOffice.Orleans/Program.cs
+++ b/Billing/src/Billing.BackOffice.Orleans/Program.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.Hosting;
+using Operations.ServiceDefaults;
+using Operations.ServiceDefaults.HealthChecks;
+
+var builder = WebApplication.CreateSlimBuilder(args);
+
+builder.AddServiceDefaults();
+builder.AddKeyedAzureTableClient("clustering");
+builder.AddKeyedAzureTableClient("grain-state");
+builder.Host.UseOrleans((context, siloBuilder) =>
+{
+    siloBuilder.UseAzureStorageClustering(options =>
+        options.ConfigureTableServiceClient(
+            context.Configuration.GetConnectionString("Clustering")));
+
+    siloBuilder.AddAzureTableGrainStorageAsDefault(options =>
+        options.ConfigureTableServiceClient(
+            context.Configuration.GetConnectionString("GrainState")));
+
+    siloBuilder.Configure<Orleans.Configuration.ClusterOptions>(
+        context.Configuration.GetSection("Orleans"));
+});
+
+var app = builder.Build();
+
+app.MapDefaultHealthCheckEndpoints();
+
+app.MapPost("/invoices/{id:guid}/pay", async (Guid id, decimal amount, IGrainFactory grains) =>
+{
+    var grain = grains.GetGrain<Billing.BackOffice.Orleans.Grains.IInvoiceGrain>(id);
+    await grain.Pay(amount);
+    return Results.Accepted();
+});
+
+app.MapGet("/invoices/{id:guid}", async (Guid id, IGrainFactory grains) =>
+{
+    var grain = grains.GetGrain<Billing.BackOffice.Orleans.Grains.IInvoiceGrain>(id);
+    return Results.Ok(await grain.GetState());
+});
+
+await app.RunAsync();

--- a/Billing/src/Billing.BackOffice.Orleans/Properties/launchSettings.json
+++ b/Billing/src/Billing.BackOffice.Orleans/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5199",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:7240;http://localhost:5199",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/Billing/src/Billing.BackOffice.Orleans/appsettings.Development.json
+++ b/Billing/src/Billing.BackOffice.Orleans/appsettings.Development.json
@@ -1,0 +1,30 @@
+{
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Billing": "Debug",
+        "Microsoft": "Warning",
+        "Microsoft.AspNetCore": "Warning"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Sixteen, Serilog.Sinks.Console",
+          "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} <s:{SourceContext}>{NewLine}{Exception}"
+        }
+      }
+    ]
+  }
+  ,
+  "ConnectionStrings": {
+    "Clustering": "UseDevelopmentStorage=true",
+    "GrainState": "UseDevelopmentStorage=true"
+  },
+  "Orleans": {
+    "ClusterId": "dev",
+    "ServiceId": "billing-orleans"
+  }
+}

--- a/Billing/src/Billing.BackOffice.Orleans/appsettings.json
+++ b/Billing/src/Billing.BackOffice.Orleans/appsettings.json
@@ -1,0 +1,16 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "ConnectionStrings": {
+    "Clustering": "<Your_Azure_Storage_Connection>",
+    "GrainState": "<Your_Azure_Storage_Connection>"
+  },
+  "Orleans": {
+    "ClusterId": "billing-cluster",
+    "ServiceId": "billing-orleans"
+  }
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -54,5 +54,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
     <PackageVersion Include="xunit.v3" Version="2.0.3" />
+    <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="9.3.0" />
+    <PackageVersion Include="Aspire.Hosting.Orleans" Version="9.3.0" />
+    <PackageVersion Include="Aspire.Azure.Data.Tables" Version="9.3.0" />
+    <PackageVersion Include="Microsoft.Orleans.Server" Version="9.1.2" />
+    <PackageVersion Include="Microsoft.Orleans.Clustering.AzureStorage" Version="9.1.2" />
+    <PackageVersion Include="Microsoft.Orleans.Persistence.AzureStorage" Version="9.1.2" />
   </ItemGroup>
 </Project>

--- a/Operations.slnx
+++ b/Operations.slnx
@@ -12,6 +12,7 @@
     <Project Path="Billing\src\Billing.Api\Billing.Api.csproj" Type="Classic C#" />
     <Project Path="Billing\src\Billing.AppHost\Billing.AppHost.csproj" Type="Classic C#" />
     <Project Path="Billing\src\Billing.BackOffice\Billing.BackOffice.csproj" Type="Classic C#" />
+    <Project Path="Billing\src\Billing.BackOffice.Orleans\Billing.BackOffice.Orleans.csproj" Type="Classic C#" />
     <Project Path="Billing\src\Billing.Contracts\Billing.Contracts.csproj" Type="Classic C#" />
     <Project Path="Billing\src\Billing\Billing.csproj" Type="Classic C#" />
   </Folder>


### PR DESCRIPTION
## Summary
- add sample invoice grain using Orleans persistent state
- configure Orleans silo with Azure Table clustering and storage
- expose endpoints to pay invoices and retrieve their state
- provide production and development appsettings for Azure configuration

## Testing
- `dotnet format --no-restore`
- `dotnet build Operations.slnx`


------
https://chatgpt.com/codex/tasks/task_e_6844f5981f70832288091d515ff1067a